### PR TITLE
QuickSettingsTileService  exported:true

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,7 +64,7 @@
             android:icon="@drawable/ic_quick_settings_tile"
             android:label="@string/app.quickSettingsTile"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>


### PR DESCRIPTION
Mentioned in #67 the QuickSettingsTileService must be exported
Closes #67 