### PR TITLE
fix: list item checked state being confused

### DIFF
--- a/app/src/main/java/com/flx_apps/digitaldetox/ui/screens/app_exceptions/AppExceptionsScreen.kt
+++ b/app/src/main/java/com/flx_apps/digitaldetox/ui/screens/app_exceptions/AppExceptionsScreen.kt
@@ -159,7 +159,7 @@ fun InstalledAppsList(
             item {
                 InfoCard(infoText = stringResource(id = R.string.feature_settings_exceptions_description))
             }
-            items(appExceptions) { appException ->
+            items(appExceptions, key = { item -> item.packageName }) { appException ->
                 AppExceptionListItem(appException)
             }
         }


### PR DESCRIPTION
add item.packageName as item key