### PR TITLE
Fix: grayscale "permissions required" feedback

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.flx_apps.digitaldetox"
         minSdk = 26
         targetSdk = 33
-        versionCode = 20003
-        versionName = "2.0.3"
+        versionCode = 20004
+        versionName = "2.0.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/flx_apps/digitaldetox/feature_types/NeedsPermissionsFeature.kt
+++ b/app/src/main/java/com/flx_apps/digitaldetox/feature_types/NeedsPermissionsFeature.kt
@@ -1,7 +1,10 @@
 package com.flx_apps.digitaldetox.feature_types
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.provider.Settings
+import com.flx_apps.digitaldetox.R
+import com.flx_apps.digitaldetox.ui.screens.nav_host.NavViewModel
 import com.flx_apps.digitaldetox.util.NavigationUtil
 
 /**
@@ -19,7 +22,7 @@ interface NeedsPermissionsFeature {
     /**
      * This method will be called when the user clicks on the Snackbar to request the permissions.
      */
-    fun requestPermissions(context: Context)
+    fun requestPermissions(context: Context, navViewModel: NavViewModel)
 }
 
 /**
@@ -37,7 +40,29 @@ class NeedsDrawOverlayPermissionFeature : NeedsPermissionsFeature {
     /**
      * Call this method to request the [android.Manifest.permission.SYSTEM_ALERT_WINDOW]
      */
-    override fun requestPermissions(context: Context) {
+    override fun requestPermissions(context: Context, navViewModel: NavViewModel) {
         NavigationUtil.openOverlayPermissionsSettings(context)
+    }
+}
+
+/**
+ * A feature that needs the [android.Manifest.permission.WRITE_SECURE_SETTINGS] permission in order
+ * to work.
+ */
+class NeedsWriteSecureSettingsPermission : NeedsPermissionsFeature {
+    /**
+     * Checks whether the app has the [android.Manifest.permission.WRITE_SECURE_SETTINGS] permission.
+     */
+    override fun hasPermissions(context: Context): Boolean {
+        return context.checkCallingOrSelfPermission("android.permission.WRITE_SECURE_SETTINGS") == PackageManager.PERMISSION_GRANTED
+    }
+
+    /**
+     * Call this method to request the [android.Manifest.permission.WRITE_SECURE_SETTINGS]
+     */
+    override fun requestPermissions(context: Context, navViewModel: NavViewModel) {
+        navViewModel.openPermissionsRequiredScreen(
+            context.getString(R.string.rootCommand_grantWriteSecuritySettingsPermission),
+        )
     }
 }

--- a/app/src/main/java/com/flx_apps/digitaldetox/features/DoNotDisturbFeature.kt
+++ b/app/src/main/java/com/flx_apps/digitaldetox/features/DoNotDisturbFeature.kt
@@ -11,6 +11,7 @@ import com.flx_apps.digitaldetox.feature_types.NeedsPermissionsFeature
 import com.flx_apps.digitaldetox.feature_types.OnAppOpenedSubscriptionFeature
 import com.flx_apps.digitaldetox.feature_types.SupportsScheduleFeature
 import com.flx_apps.digitaldetox.ui.screens.feature.do_not_disturb.DoNotDisturbFeatureSettingsSection
+import com.flx_apps.digitaldetox.ui.screens.nav_host.NavViewModel
 import com.flx_apps.digitaldetox.util.NavigationUtil
 
 val DoNotDisturbFeatureId = Feature.createId(DoNotDisturbFeature::class.java)
@@ -99,7 +100,7 @@ object DoNotDisturbFeature : Feature(), OnAppOpenedSubscriptionFeature, NeedsPer
     /**
      * Opens the system settings to grant the permission to change the zen mode.
      */
-    override fun requestPermissions(context: Context) {
+    override fun requestPermissions(context: Context, navViewModel: NavViewModel) {
         NavigationUtil.openDoNotDisturbSystemSettings(context)
     }
 }

--- a/app/src/main/java/com/flx_apps/digitaldetox/features/GrayscaleAppsFeature.kt
+++ b/app/src/main/java/com/flx_apps/digitaldetox/features/GrayscaleAppsFeature.kt
@@ -11,6 +11,8 @@ import com.flx_apps.digitaldetox.data.DataStoreProperty
 import com.flx_apps.digitaldetox.feature_types.AppExceptionListType
 import com.flx_apps.digitaldetox.feature_types.Feature
 import com.flx_apps.digitaldetox.feature_types.FeatureTexts
+import com.flx_apps.digitaldetox.feature_types.NeedsPermissionsFeature
+import com.flx_apps.digitaldetox.feature_types.NeedsWriteSecureSettingsPermission
 import com.flx_apps.digitaldetox.feature_types.OnAppOpenedSubscriptionFeature
 import com.flx_apps.digitaldetox.feature_types.OnScreenTurnedOffSubscriptionFeature
 import com.flx_apps.digitaldetox.feature_types.ScreenTimeTrackingFeature
@@ -34,7 +36,8 @@ object GrayscaleAppsFeature : Feature(), OnAppOpenedSubscriptionFeature,
     OnScreenTurnedOffSubscriptionFeature,
     SupportsScheduleFeature by SupportsScheduleFeature.Impl(GrayscaleAppsFeatureId),
     SupportsAppExceptionsFeature by SupportsAppExceptionsFeature.Impl(GrayscaleAppsFeatureId),
-    ScreenTimeTrackingFeature by ScreenTimeTrackingFeature.Impl(GrayscaleAppsFeatureId) {
+    ScreenTimeTrackingFeature by ScreenTimeTrackingFeature.Impl(GrayscaleAppsFeatureId),
+    NeedsPermissionsFeature by NeedsWriteSecureSettingsPermission() {
     override val texts: FeatureTexts = FeatureTexts(
         R.string.feature_grayscale,
         R.string.feature_grayscale_subtitle,

--- a/app/src/main/java/com/flx_apps/digitaldetox/ui/screens/feature/FeatureScreen.kt
+++ b/app/src/main/java/com/flx_apps/digitaldetox/ui/screens/feature/FeatureScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -23,8 +24,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.flx_apps.digitaldetox.MainActivity
+import com.flx_apps.digitaldetox.R
 import com.flx_apps.digitaldetox.feature_types.Feature
 import com.flx_apps.digitaldetox.feature_types.FeatureId
+import com.flx_apps.digitaldetox.feature_types.NeedsPermissionsFeature
+import com.flx_apps.digitaldetox.ui.screens.nav_host.NavViewModel
 import com.flx_apps.digitaldetox.ui.widgets.InfoCard
 
 /**
@@ -88,11 +92,23 @@ fun FeatureScreen(
 @Composable
 fun FeatureActivationSwitch(
     featureViewModel: FeatureViewModel = viewModel(),
+    navViewModel: NavViewModel = NavViewModel.navViewModel()
 ) {
+    val context = LocalContext.current
     Switch(modifier = Modifier.padding(end = 8.dp),
         checked = featureViewModel.featureIsActive.collectAsState().value,
         onCheckedChange = {
-            featureViewModel.toggleFeatureActive()
+            if (featureViewModel.toggleFeatureActive() == null) {
+                featureViewModel.showSnackbar(message = context.getString(R.string.action_requestPermissions),
+                    actionLabel = context.getString(R.string.action_go),
+                    onResult = { snackbarResult ->
+                        if (snackbarResult == SnackbarResult.ActionPerformed) {
+                            (featureViewModel.feature as NeedsPermissionsFeature).requestPermissions(
+                                context, navViewModel
+                            )
+                        }
+                    })
+            }
         })
 }
 

--- a/app/src/main/java/com/flx_apps/digitaldetox/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/flx_apps/digitaldetox/ui/screens/home/HomeScreen.kt
@@ -69,6 +69,7 @@ import com.flx_apps.digitaldetox.util.NavigationUtil
 import com.flx_apps.digitaldetox.util.observeAsState
 import com.flx_apps.digitaldetox.util.toHrMinString
 import kotlinx.coroutines.flow.MutableStateFlow
+import timber.log.Timber
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
@@ -84,6 +85,7 @@ fun HomeScreen(
     homeViewModel: HomeViewModel = viewModel()
 ) {
     val detoxDroidState: DetoxDroidState = homeViewModel.detoxDroidState.collectAsState().value
+    Timber.d("detoxDroidState = $detoxDroidState")
     val snackbarHostState = remember { SnackbarHostState() }
     Scaffold(snackbarHost = {
         SnackbarHost(hostState = snackbarHostState)
@@ -108,6 +110,7 @@ private fun HomeScreenSnackbarContents(
 ) {
     val context = LocalContext.current
     val snackbarState = homeViewModel.snackbarState.collectAsState().value
+    Timber.d("snackbarState = $snackbarState")
     if (snackbarState == HomeScreenSnackbarState.ShowStartAcccessibilityServiceManually) {
         // show snackbar to request the write secure settings permission
         LaunchedEffect(key1 = "", block = {

--- a/app/src/main/java/com/flx_apps/digitaldetox/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/flx_apps/digitaldetox/ui/screens/home/HomeViewModel.kt
@@ -41,10 +41,6 @@ class HomeViewModel @Inject constructor(
 
     /**
      * Toggles the state of the accessibility service.
-     * TODO right now, this method requires the WRITE_SECURE_SETTINGS permission. We should consider
-     *   using the AccessibilityService API instead, because some features of DetoxDroid can be
-     *   used without the WRITE_SECURE_SETTINGS permission. (However, DetoxDroid makes much more
-     *   sense if this permission is granted.)
      * @return the new state of the accessibility service or null if the (de-)activation failed
      * @see DetoxDroidAccessibilityService
      * @see DetoxDroidState

--- a/app/src/main/java/com/flx_apps/digitaldetox/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/flx_apps/digitaldetox/ui/screens/home/HomeViewModel.kt
@@ -15,10 +15,17 @@ import kotlinx.coroutines.flow.StateFlow
 import timber.log.Timber
 import javax.inject.Inject
 
-
+/**
+ * The component name of the accessibility service. This is used to enable and disable the service.
+ * @see HomeViewModel.activateAccessibilityService
+ * @see HomeViewModel.disableAccessibilityService
+ */
 val AccessibilityServiceComponent =
     DetoxDroidApplication::class.java.`package`!!.name + "/" + DetoxDroidAccessibilityService::class.java.name
 
+/**
+ * The state of the snackbar on the home screen.
+ */
 enum class HomeScreenSnackbarState {
     Hidden, ShowStartAcccessibilityServiceManually
 }
@@ -49,16 +56,10 @@ class HomeViewModel @Inject constructor(
         Timber.d("state = ${detoxDroidState.value}")
         val shouldBeRunning = detoxDroidState.value != DetoxDroidState.Active
         kotlin.runCatching { // if we don't have the permission to write secure settings, an exception will be thrown
-            if (shouldBeRunning) {
-                activateAccessibilityService()
-                if (DetoxDroidAccessibilityService.updateState() == DetoxDroidState.Active) {
-                    return DetoxDroidState.Active
-                }
-            } else {
-                disableAccessibilityService()
-                if (DetoxDroidAccessibilityService.updateState() == DetoxDroidState.Inactive) {
-                    return DetoxDroidState.Inactive
-                }
+            if (shouldBeRunning && activateAccessibilityService()) {
+                return DetoxDroidState.Active
+            } else if (!shouldBeRunning && disableAccessibilityService()) {
+                return DetoxDroidState.Inactive
             }
         }
 
@@ -77,7 +78,7 @@ class HomeViewModel @Inject constructor(
      * manually once to make sure it is running.
      * @see DetoxDroidAccessibilityService
      */
-    private fun activateAccessibilityService() {
+    private fun activateAccessibilityService(): Boolean {
         val accessibilityServices = Settings.Secure.getString(
             contentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
         ).orEmpty()
@@ -89,18 +90,18 @@ class HomeViewModel @Inject constructor(
         Settings.Secure.putString(
             contentResolver, Settings.Secure.ACCESSIBILITY_ENABLED, "1"
         )
-        application.startService(
+        return application.startService(
             Intent(
                 application, DetoxDroidAccessibilityService::class.java
             )
-        )
+        ) != null
     }
 
     /**
      * Disables the accessibility service.
      * @see DetoxDroidAccessibilityService
      */
-    private fun disableAccessibilityService() {
+    private fun disableAccessibilityService(): Boolean {
         val accessibilityServices = Settings.Secure.getString(
             contentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES
         ).orEmpty()
@@ -109,7 +110,7 @@ class HomeViewModel @Inject constructor(
             Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
             accessibilityServices.replace(AccessibilityServiceComponent, "").trim(':')
         )
-        application.stopService(
+        return application.stopService(
             Intent(
                 application, DetoxDroidAccessibilityService::class.java
             )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.1" apply false
+    id("com.android.application") version "8.1.3" apply false
     id("org.jetbrains.kotlin.android") version "1.8.10" apply false
     // DI
     id("com.google.dagger.hilt.android") version "2.44" apply false


### PR DESCRIPTION
Fix these issues:
- Error feedback was not working properly for the Automatic Grayscale feature, if WRITE_SECURE_SETTINGS_PERMISSION were not granted
- On some devices, the snackbar on the main screen was shown, when DetoxDroid has been (successfully) started or stopped

Also, update the Android Gradle Plugin from 8.1.1 to 8.1.3.