### PR TITLE
fix: close foreground app after doomscrolling was detected

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
     <!-- SYSTEM_ALERT_WINDOW permission in order to show the overlay for disabling apps / breaking infinite scrolling -->
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
+    <!-- KILL_BACKGROUND_PROCESSES permission in order to kill apps from the overlay -->
+    <uses-permission android:name="android.permission.KILL_BACKGROUND_PROCESSES" />
+
     <!-- DEVICE_ADMIN permission in order to deactivate apps -->
     <uses-permission
         android:name="android.permission.BIND_DEVICE_ADMIN"


### PR DESCRIPTION
- add permission to AndroidManifest.xml
this will probably still not fix the issue due to Android limitations, but it should be theoretically necessary nonetheless