### PR TITLE
Fix bug: Grayscale feature does not turn off in allowlisted apps

### DIFF
--- a/app/src/main/java/com/flx_apps/digitaldetox/features/GrayscaleAppsFeature.kt
+++ b/app/src/main/java/com/flx_apps/digitaldetox/features/GrayscaleAppsFeature.kt
@@ -95,9 +95,14 @@ object GrayscaleAppsFeature : Feature(), OnAppOpenedSubscriptionFeature,
 
     /**
      * On start, we trigger [onAppOpened] once to turn the grayscale filter on or off depending on
-     * the current app.
+     * the current app. We also read the actual system state to initialize [isCurrentlyGrayscale],
+     * so that saved defaults are not overwritten if the service (re-) starts while grayscale is active.
      */
     override fun onStart(context: Context) {
+        val contentResolver = context.contentResolver
+        isCurrentlyGrayscale =
+            Settings.Secure.getInt(contentResolver, DISPLAY_DALTONIZER_ENABLED, 0) == 1 &&
+            Settings.Secure.getInt(contentResolver, DISPLAY_DALTONIZER, -1) == 0
         val accessibilityEvent = AccessibilityEventUtil.createEvent()
         onAppOpened(context, accessibilityEvent.packageName.toString(), accessibilityEvent)
     }
@@ -170,8 +175,9 @@ object GrayscaleAppsFeature : Feature(), OnAppOpenedSubscriptionFeature,
     ): Boolean {
         val contentResolver = context.contentResolver
 
-        if (grayscale) {
+        if (grayscale && !isCurrentlyGrayscale) {
             // save the current color correction state (enabled + mode)
+            // Only do this when currently not in grayscale, to not save grayscale as a default.
             defaultDaltonizerEnabled = Settings.Secure.getInt(
                 contentResolver, DISPLAY_DALTONIZER_ENABLED, 0
             )


### PR DESCRIPTION
Hey, first of all: thank you for your work on the app! It's a great idea and I've been using it for a while now.

For the last couple of releases (after upgrading from a previous release), my phone would stay in grayscale mode, even when switching to an allowlisted app. This only happens when the grayscale feature is setup while grayscale is already active.
I believe #143 could also be explained by this.

## Steps to reproduce
- Turn on grayscale mode
- Newly install or upgrade DetoxDroid
- Enable the grayscale feature
- The app saves the current grayscale state as the default  (in the form of `DISPLAY_DALTONIZER_ENABLED = 1` and `DISPLAY_DALTONIZER = 0`)
- When switching to an allowlisted app, DetoxDroid restores these defaults. The device remains stuck in grayscale mode.

## The fix
Have the app check the current grayscale state at the start of the service and update the internal tracking variable. This prevents saving the grayscale settings as a default.

---

I tried to keep the change as minimally invasive as possible. I'd be happy to see it merged :)

